### PR TITLE
Add InfluxDB support to CollectD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN           apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 232E4010A
 RUN           apt-get -y update
 RUN           apt-get -y install collectd curl vim python-pip
 
-ADD           collectd.conf.tpl /etc/collectd/collectd.conf.tpl
+ADD           configs/ /etc/collectd/configs
+
 ADD           start /usr/bin/start
 
 EXPOSE        8125

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 # collectd-docker
 
-Simple [CollectD](https://github.com/collectd/collectd) instance running within a [Docker](https://github.com/docker/docker) container. It sends CPU statistics every 10 seconds to a specified endpoint (see below), which can accept traffic from the [write_graphite](https://collectd.org/wiki/index.php/Plugin:Write_Graphite) plugin.
+Simple [CollectD](https://github.com/collectd/collectd) instance running within a [Docker](https://github.com/docker/docker) container. It sends CPU statistics every 10 seconds to a specified endpoint, either [Graphite](https://github.com/graphite-project) or [InfluxDB](https://github.com/influxdb/influxdb).
 
-**Note**
-
-* The primary purpose of this container is to test the [Ruby CollectD](https://github.com/revett/collectd) gem locally.
-* The CollectD instance also accepts traffic from [StatsD](https://github.com/etsy/statsd/) clients on `localhost:8125`.
+**Note** - also accepts traffic from [StatsD](https://github.com/etsy/statsd/) clients on `localhost:8125`.
 
 ## Setup
 
 1. [Install Docker](http://docs.docker.com/installation/mac/).
-2. Pull the latest image from the Docker [registry](https://registry.hub.docker.com/u/revett/collectd-carbon/):
+2. Pull the latest image from the Docker [registry](https://registry.hub.docker.com/u/revett/collectd/):
 
 ```
 docker pull revett/collectd
@@ -21,7 +18,7 @@ docker pull revett/collectd
 Start the container:
 
 ```
-docker run -d -e EP_HOST=example.com revett/collectd
+docker run -d -e CONFIG_TYPE=influxdb -e EP_HOST=example.com -e EP_PORT 2003 revett/collectd
 ```
 
 ### Environment Variables
@@ -30,21 +27,27 @@ You **must** replace the required environment variables within the `docker run` 
 
 **Required**:
 
+* `CONFIG_TYPE`
+  - Either: `graphite` or `influxdb`
 * `EP_HOST`
   - IP or hostname for the endpoint.
+* `EP_PORT`
+  - Default: `2003`
+  - Port for the endpoint.
 
 **Optional**:
 
-* `HOST_NAME`, default: `collectd-docker`
-  - Used to create the namespace in Graphite (endpoint).
-* `EP_PORT`, default: `2003`
-  - Port for the endpoint.
-* `PREFIX`, default: `local.debug`
-  - Used to create the namespace in Graphite (endpoint)
+* `HOST_NAME`
+  - Default: `collectd-docker`
+  - Used to create the namespace.
+* `PREFIX`
+  - Default: `local.debug`
+  - Used to create the namespace.
+  - **Graphite** only.
 
 ### Namespace
 
-When viewing the metrics within [Grafana](http://grafana.org/) for example, they will come under the following namespace:
+When viewing the metrics within [Grafana](http://grafana.org/) via Graphite for example, they will come under the following namespace:
 
 ```
 {{PREFIX}}.{{HOST_NAME}}.cpu-*

--- a/collectd.influxdb.conf.tpl
+++ b/collectd.influxdb.conf.tpl
@@ -1,0 +1,22 @@
+Hostname "{{ HOST_NAME | default("collectd-docker") }}"
+
+FQDNLookup false
+Interval 10
+Timeout 2
+ReadThreads 5
+
+LoadPlugin statsd
+LoadPlugin cpu
+LoadPlugin network
+
+<Plugin statsd>
+  Host "::"
+  Port "8125"
+  DeleteSets      true
+  TimerPercentile 90.0
+</Plugin>
+
+<Plugin network>
+  Server "collectd-link" "8125"
+  ReportStats true
+</Plugin>

--- a/collectd.influxdb.conf.tpl
+++ b/collectd.influxdb.conf.tpl
@@ -17,6 +17,6 @@ LoadPlugin network
 </Plugin>
 
 <Plugin network>
-  Server "collectd-link" "8125"
+  Server "{{ EP_HOST }}" "{{ EP_PORT | default(25826) }}"
   ReportStats true
 </Plugin>

--- a/configs/collectd.graphite.conf.tpl
+++ b/configs/collectd.graphite.conf.tpl
@@ -19,7 +19,7 @@ LoadPlugin write_graphite
 <Plugin "write_graphite">
  <Node "endpoint">
    Host "{{ EP_HOST }}"
-   Port "{{ EP_PORT | default(2003) }}"
+   Port "{{ EP_PORT }}"
    Protocol "tcp"
    LogSendErrors true
    EscapeCharacter "_"

--- a/configs/collectd.influxdb.conf.tpl
+++ b/configs/collectd.influxdb.conf.tpl
@@ -17,6 +17,6 @@ LoadPlugin network
 </Plugin>
 
 <Plugin network>
-  Server "{{ EP_HOST }}" "{{ EP_PORT | default(25826) }}"
+  Server "{{ EP_HOST }}" "{{ EP_PORT }}"
   ReportStats true
 </Plugin>

--- a/start
+++ b/start
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cp /etc/collectd/configs/collectd.$CONFIG_TYPE.conf.tpl /etc/collectd/collectd.conf.tpl
+
 envtpl /etc/collectd/collectd.conf.tpl
 
 collectd -f


### PR DESCRIPTION
### Summary

- Adds support for influxdb to container.
- Multi-config support.

#### Multi-config

The container now includes a config for writing to both Graphite and InfluxDB. You can specify which config you want to use by setting the `CONFIG_TYPE` environment variable (within `docker run`) to either:

- `graphite`
- `influxdb`

For example:

```
docker run -d -e EP_HOST=example.com -e EP_PORT=2003 -e CONFIG_TYPE=influxdb revett/collectd
```